### PR TITLE
Navigation Controller embedded

### DIFF
--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZQK-6x-0dJ">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -43,13 +43,14 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
+                    <navigationItem key="navigationItem" id="LYi-8y-fpH"/>
                     <connections>
                         <outlet property="characterListTableView" destination="g1e-xP-X0g" id="dEU-zG-Wdp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="136.80000000000001" y="98.50074962518741"/>
+            <point key="canvasLocation" x="1076" y="98.50074962518741"/>
         </scene>
         <!--Character Detail View Controller-->
         <scene sceneID="jEC-n3-IjC">
@@ -64,7 +65,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yHI-Ke-1Sm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1042" y="95"/>
+            <point key="canvasLocation" x="1980" y="94.902548725637189"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Q5k-ZC-uBq">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="ZQK-6x-0dJ" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="fXF-xi-7si">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="bSc-IJ-wND"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="YS4-Ld-2XD" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="136.80000000000001" y="98.50074962518741"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
## What you did :question:
- Embedded navigation controller to add the ability for user to navigate back to the CharacterListViewController from the CharacterDetailViewController

## How you did it :white_check_mark:
- Selected the CharacterListViewController
- Selected `Editor` -> `Embed In` -> `Navigation Controller`


## How to test it :microscope:
- Run the app
- Tap any character's name
- Tap 'Back'
- App should navigate back to the Character List View


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-27 at 15 21 10](https://user-images.githubusercontent.com/8409475/47608496-bb2bdc80-d9fc-11e8-852c-25c97d678150.png)
![simulator screen shot - iphone xr - 2018-10-27 at 15 21 15](https://user-images.githubusercontent.com/8409475/47608500-c121bd80-d9fc-11e8-9902-902b83afc601.png)
![simulator screen shot - iphone xr - 2018-10-27 at 15 27 10](https://user-images.githubusercontent.com/8409475/47608509-d4cd2400-d9fc-11e8-8339-45ae38e71398.png)
