### PR TITLE
Add detail ui

### DIFF
--- a/StarWarsDetail/StarWarsDetail/Controllers/CharacterDetailViewController.swift
+++ b/StarWarsDetail/StarWarsDetail/Controllers/CharacterDetailViewController.swift
@@ -10,6 +10,15 @@ import UIKit
 
 class CharacterDetailViewController: UIViewController {
     
+    // MARK: Outlets
+    
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var birthYearLabel: UILabel!
+    @IBOutlet weak var genderLabel: UILabel!
+    @IBOutlet weak var homeworldLabel: UILabel!
+    @IBOutlet weak var speciesLabel: UILabel!
+    
+    
     // MARK: Properties
     
     var person: Person?
@@ -54,6 +63,8 @@ class CharacterDetailViewController: UIViewController {
         guard let personHomeworldObject = personHomeworldObject else { return }
         print("Homeworld: \(personHomeworldObject.name)")
     }
+    
+    
 
 }
 

--- a/StarWarsDetail/StarWarsDetail/Controllers/CharacterDetailViewController.swift
+++ b/StarWarsDetail/StarWarsDetail/Controllers/CharacterDetailViewController.swift
@@ -28,9 +28,12 @@ class CharacterDetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        print("🙋‍♀️\(person!.name)")
+        
         getSpeciesData()
         getHomeworldData()
+        populateNameLabel()
+        populateBirthYearLabel()
+        populateGenderLabel()
     }
     
     // MARK: Methods
@@ -55,16 +58,32 @@ class CharacterDetailViewController: UIViewController {
     
     func populateSpeciesLabel() {
         for species in personSpeciesArray {
-            print("Species: \(species.name)")
+            if personSpeciesArray.count == 1 {
+                speciesLabel.text = species.name
+            } else {
+                var speciesString = ""
+                speciesString += "\(species.name) \n"
+                speciesLabel.text = speciesString
+            }
         }
     }
     
     func populateHomeworldLabel() {
         guard let personHomeworldObject = personHomeworldObject else { return }
-        print("Homeworld: \(personHomeworldObject.name)")
+        homeworldLabel.text = personHomeworldObject.name
     }
     
+    func populateNameLabel() {
+        nameLabel.text = person?.name
+    }
     
+    func populateBirthYearLabel() {
+        birthYearLabel.text = person?.birth_year
+    }
+    
+    func populateGenderLabel() {
+        genderLabel.text = person?.gender
+    }
 
 }
 

--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -64,34 +64,34 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="L9U-gQ-D7Z">
-                                        <rect key="frame" x="0.0" y="0.0" width="187.5" height="603"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="158" height="603"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3XW-jJ-MTf">
-                                                <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3XW-jJ-MTf">
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJ8-BY-GKi">
-                                                <rect key="frame" x="0.0" y="145.5" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Birth Year:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJ8-BY-GKi">
+                                                <rect key="frame" x="0.0" y="145.5" width="79.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eB2-Ws-nSy">
-                                                <rect key="frame" x="0.0" y="291.5" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gender:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eB2-Ws-nSy">
+                                                <rect key="frame" x="0.0" y="291.5" width="61.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z6r-56-JJp">
-                                                <rect key="frame" x="0.0" y="437" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Species:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z6r-56-JJp">
+                                                <rect key="frame" x="0.0" y="437" width="65.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="imO-Rr-BZN">
-                                                <rect key="frame" x="0.0" y="582.5" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Homeworld:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="imO-Rr-BZN">
+                                                <rect key="frame" x="0.0" y="582.5" width="92.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -99,34 +99,34 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
-                                        <rect key="frame" x="187.5" y="0.0" width="187.5" height="603"/>
+                                        <rect key="frame" x="158" y="0.0" width="217" height="603"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">
-                                                <rect key="frame" x="145.5" y="0.0" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">
+                                                <rect key="frame" x="133" y="0.0" width="84" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPf-Lw-NSK">
-                                                <rect key="frame" x="145.5" y="145.5" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="birthYearLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPf-Lw-NSK">
+                                                <rect key="frame" x="107" y="145.5" width="110" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddm-lC-0fq">
-                                                <rect key="frame" x="145.5" y="291.5" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="genderLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddm-lC-0fq">
+                                                <rect key="frame" x="121" y="291.5" width="96" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yyb-ZS-vBC">
-                                                <rect key="frame" x="145.5" y="437" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="speciesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yyb-ZS-vBC">
+                                                <rect key="frame" x="116.5" y="437" width="100.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sdb-5r-Bo8">
-                                                <rect key="frame" x="145.5" y="582.5" width="42" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="homeworldLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sdb-5r-Bo8">
+                                                <rect key="frame" x="90" y="582.5" width="127" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>

--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -59,7 +59,90 @@
                     <view key="view" contentMode="scaleToFill" id="ITt-Jm-d6f">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="bAw-pw-BCr">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="L9U-gQ-D7Z">
+                                        <rect key="frame" x="0.0" y="0.0" width="187.5" height="603"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3XW-jJ-MTf">
+                                                <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJ8-BY-GKi">
+                                                <rect key="frame" x="0.0" y="145.5" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eB2-Ws-nSy">
+                                                <rect key="frame" x="0.0" y="291.5" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z6r-56-JJp">
+                                                <rect key="frame" x="0.0" y="437" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="imO-Rr-BZN">
+                                                <rect key="frame" x="0.0" y="582.5" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
+                                        <rect key="frame" x="187.5" y="0.0" width="187.5" height="603"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">
+                                                <rect key="frame" x="145.5" y="0.0" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPf-Lw-NSK">
+                                                <rect key="frame" x="145.5" y="145.5" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddm-lC-0fq">
+                                                <rect key="frame" x="145.5" y="291.5" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yyb-ZS-vBC">
+                                                <rect key="frame" x="145.5" y="437" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sdb-5r-Bo8">
+                                                <rect key="frame" x="145.5" y="582.5" width="42" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="gHP-Vp-guv" firstAttribute="bottom" secondItem="bAw-pw-BCr" secondAttribute="bottom" id="E7Y-vV-7Zh"/>
+                            <constraint firstItem="bAw-pw-BCr" firstAttribute="top" secondItem="gHP-Vp-guv" secondAttribute="top" id="bdp-SU-1CN"/>
+                            <constraint firstItem="bAw-pw-BCr" firstAttribute="leading" secondItem="gHP-Vp-guv" secondAttribute="leading" id="oP7-Gg-Oaz"/>
+                            <constraint firstItem="gHP-Vp-guv" firstAttribute="trailing" secondItem="bAw-pw-BCr" secondAttribute="trailing" id="qoq-Fy-fhQ"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="gHP-Vp-guv"/>
                     </view>
                 </viewController>

--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -145,6 +145,13 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="gHP-Vp-guv"/>
                     </view>
+                    <connections>
+                        <outlet property="birthYearLabel" destination="XPf-Lw-NSK" id="3Aa-7f-tMV"/>
+                        <outlet property="genderLabel" destination="ddm-lC-0fq" id="YMX-EH-3Ib"/>
+                        <outlet property="homeworldLabel" destination="Yyb-ZS-vBC" id="uhS-HU-mPk"/>
+                        <outlet property="nameLabel" destination="3n8-Sy-TSl" id="qda-qy-YdG"/>
+                        <outlet property="speciesLabel" destination="Sdb-5r-Bo8" id="f9W-Cy-J9s"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="yHI-Ke-1Sm" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -98,7 +98,7 @@
                                             </label>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
                                         <rect key="frame" x="149.5" y="0.0" width="205.5" height="353"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nameLabel" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">

--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -61,10 +61,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="bAw-pw-BCr">
-                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <rect key="frame" x="20" y="164" width="355" height="353"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="L9U-gQ-D7Z">
-                                        <rect key="frame" x="0.0" y="0.0" width="158" height="603"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="149.5" height="353"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3XW-jJ-MTf">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="20.5"/>
@@ -73,25 +73,25 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Birth Year:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJ8-BY-GKi">
-                                                <rect key="frame" x="0.0" y="145.5" width="79.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="83" width="79.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gender:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eB2-Ws-nSy">
-                                                <rect key="frame" x="0.0" y="291.5" width="61.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="166.5" width="61.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Species:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z6r-56-JJp">
-                                                <rect key="frame" x="0.0" y="437" width="65.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Homeworld:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z6r-56-JJp">
+                                                <rect key="frame" x="0.0" y="249.5" width="92.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Homeworld:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="imO-Rr-BZN">
-                                                <rect key="frame" x="0.0" y="582.5" width="92.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Species:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="imO-Rr-BZN">
+                                                <rect key="frame" x="0.0" y="332.5" width="65.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -99,34 +99,34 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
-                                        <rect key="frame" x="158" y="0.0" width="217" height="603"/>
+                                        <rect key="frame" x="149.5" y="0.0" width="205.5" height="353"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nameLabel" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">
                                                 <rect key="frame" x="0.0" y="0.0" width="84" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="birthYearLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPf-Lw-NSK">
-                                                <rect key="frame" x="0.0" y="145.5" width="110" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="birthYearLabel" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPf-Lw-NSK">
+                                                <rect key="frame" x="0.0" y="83" width="110" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="genderLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddm-lC-0fq">
-                                                <rect key="frame" x="0.0" y="291.5" width="96" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="genderLabel" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddm-lC-0fq">
+                                                <rect key="frame" x="0.0" y="166.5" width="96" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="speciesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yyb-ZS-vBC">
-                                                <rect key="frame" x="0.0" y="437" width="100.5" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="homeworldLabel" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yyb-ZS-vBC">
+                                                <rect key="frame" x="0.0" y="249.5" width="127" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="homeworldLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sdb-5r-Bo8">
-                                                <rect key="frame" x="0.0" y="582.5" width="127" height="20.5"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="speciesLabel" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sdb-5r-Bo8">
+                                                <rect key="frame" x="0.0" y="332.5" width="100.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -134,23 +134,13 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="L9U-gQ-D7Z" firstAttribute="leading" secondItem="bAw-pw-BCr" secondAttribute="leading" constant="20" id="EBa-bk-Hjw"/>
-                                    <constraint firstAttribute="bottom" secondItem="L9U-gQ-D7Z" secondAttribute="bottom" constant="20" id="HJu-PF-lKM"/>
-                                    <constraint firstAttribute="trailing" secondItem="ugb-br-G5D" secondAttribute="trailing" constant="20" id="Riz-dS-U22"/>
-                                    <constraint firstAttribute="trailing" secondItem="L9U-gQ-D7Z" secondAttribute="trailing" constant="217" id="Xbp-R5-lio"/>
-                                    <constraint firstItem="ugb-br-G5D" firstAttribute="leading" secondItem="bAw-pw-BCr" secondAttribute="leading" constant="158" id="ifV-bF-9nS"/>
-                                    <constraint firstAttribute="bottom" secondItem="ugb-br-G5D" secondAttribute="bottom" constant="20" id="jn2-6R-3G2"/>
-                                    <constraint firstItem="ugb-br-G5D" firstAttribute="top" secondItem="bAw-pw-BCr" secondAttribute="top" constant="20" id="rMh-47-vY2"/>
-                                    <constraint firstItem="L9U-gQ-D7Z" firstAttribute="top" secondItem="bAw-pw-BCr" secondAttribute="top" constant="20" id="soI-Ba-fNs"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="gHP-Vp-guv" firstAttribute="bottom" secondItem="bAw-pw-BCr" secondAttribute="bottom" id="E7Y-vV-7Zh"/>
-                            <constraint firstItem="bAw-pw-BCr" firstAttribute="top" secondItem="gHP-Vp-guv" secondAttribute="top" id="bdp-SU-1CN"/>
-                            <constraint firstItem="bAw-pw-BCr" firstAttribute="leading" secondItem="gHP-Vp-guv" secondAttribute="leading" id="oP7-Gg-Oaz"/>
+                            <constraint firstItem="gHP-Vp-guv" firstAttribute="bottom" secondItem="bAw-pw-BCr" secondAttribute="bottom" constant="150" id="E7Y-vV-7Zh"/>
+                            <constraint firstItem="bAw-pw-BCr" firstAttribute="top" secondItem="gHP-Vp-guv" secondAttribute="top" constant="100" id="bdp-SU-1CN"/>
+                            <constraint firstItem="bAw-pw-BCr" firstAttribute="leading" secondItem="gHP-Vp-guv" secondAttribute="leading" constant="20" id="oP7-Gg-Oaz"/>
                             <constraint firstItem="gHP-Vp-guv" firstAttribute="trailing" secondItem="bAw-pw-BCr" secondAttribute="trailing" id="qoq-Fy-fhQ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="gHP-Vp-guv"/>

--- a/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
+++ b/StarWarsDetail/StarWarsDetail/Views/Base.lproj/Main.storyboard
@@ -98,35 +98,35 @@
                                             </label>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ugb-br-G5D">
                                         <rect key="frame" x="158" y="0.0" width="217" height="603"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3n8-Sy-TSl">
-                                                <rect key="frame" x="133" y="0.0" width="84" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="84" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="birthYearLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XPf-Lw-NSK">
-                                                <rect key="frame" x="107" y="145.5" width="110" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="145.5" width="110" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="genderLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ddm-lC-0fq">
-                                                <rect key="frame" x="121" y="291.5" width="96" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="291.5" width="96" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="speciesLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yyb-ZS-vBC">
-                                                <rect key="frame" x="116.5" y="437" width="100.5" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="437" width="100.5" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="homeworldLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sdb-5r-Bo8">
-                                                <rect key="frame" x="90" y="582.5" width="127" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="582.5" width="127" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -134,6 +134,16 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="L9U-gQ-D7Z" firstAttribute="leading" secondItem="bAw-pw-BCr" secondAttribute="leading" constant="20" id="EBa-bk-Hjw"/>
+                                    <constraint firstAttribute="bottom" secondItem="L9U-gQ-D7Z" secondAttribute="bottom" constant="20" id="HJu-PF-lKM"/>
+                                    <constraint firstAttribute="trailing" secondItem="ugb-br-G5D" secondAttribute="trailing" constant="20" id="Riz-dS-U22"/>
+                                    <constraint firstAttribute="trailing" secondItem="L9U-gQ-D7Z" secondAttribute="trailing" constant="217" id="Xbp-R5-lio"/>
+                                    <constraint firstItem="ugb-br-G5D" firstAttribute="leading" secondItem="bAw-pw-BCr" secondAttribute="leading" constant="158" id="ifV-bF-9nS"/>
+                                    <constraint firstAttribute="bottom" secondItem="ugb-br-G5D" secondAttribute="bottom" constant="20" id="jn2-6R-3G2"/>
+                                    <constraint firstItem="ugb-br-G5D" firstAttribute="top" secondItem="bAw-pw-BCr" secondAttribute="top" constant="20" id="rMh-47-vY2"/>
+                                    <constraint firstItem="L9U-gQ-D7Z" firstAttribute="top" secondItem="bAw-pw-BCr" secondAttribute="top" constant="20" id="soI-Ba-fNs"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
## What you did :question:
- Populated the Character Detail View with the data returned in segue and API call

## How you did it :white_check_mark:
- Added methods to populate the label text of all property labels
- For species label: returning more than one species string results in multiple species listed


## How to test it :microscope:
- Run the app
- Tap any character name
- Character Detail View should appear, showing the name, birth year, gender, homeworld, and species of the selected character


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-10-27 at 20 02 36](https://user-images.githubusercontent.com/8409475/47610493-9d726d80-da24-11e8-8ef4-460a80db0c40.png)
![simulator screen shot - iphone xr - 2018-10-27 at 20 02 47](https://user-images.githubusercontent.com/8409475/47610494-a6fbd580-da24-11e8-92d7-6653c97d1eb2.png)
